### PR TITLE
Lazy from_csv Implementation 

### DIFF
--- a/aqua_blue/__init__.py
+++ b/aqua_blue/__init__.py
@@ -61,7 +61,7 @@ Here, we use both hyperbolic tangent (`tanh`) and the [error function](https://e
 ```
 """
 
-__version__ = "0.2.11"
+__version__ = "0.2.12"
 __authors__ = [
     "Jacob Jeffries",
     "Hrishikesh Belagali",

--- a/aqua_blue/datetimelikearray.py
+++ b/aqua_blue/datetimelikearray.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import numpy as np
 
-from typing import List, IO, Union, TypeVar, Type, Sequence
+from typing import List, IO, Union, TypeVar, Type, Sequence, Iterable, Optional
 
 from zoneinfo import ZoneInfo
 import datetime
@@ -35,7 +35,7 @@ class DatetimeLikeArray(np.ndarray):
     back to the specified timezone when accessed.
     """
 
-    tz: Union[datetime.tzinfo, None] = None
+    tz: Optional[datetime.tzinfo] = None
     """The timezone associated with the array. Defaults to None (assumed UTC)."""
 
     tz_offset: Union[datetime.timedelta, None] = None
@@ -83,16 +83,16 @@ class DatetimeLikeArray(np.ndarray):
         tz_offset_ = datetime.datetime.now(tz_).utcoffset()
         seconds_offset = tz_offset_.total_seconds() if tz_offset_ else 0
         np_offset = np.timedelta64(int(np.abs(seconds_offset)), 's')
-
+        
         if seconds_offset < 0:
             datetime64_array += np_offset
         else:
             datetime64_array -= np_offset
-
+        
         # Initialize an NDArray and populate with the datetime values
         obj = super().__new__(cls, datetime64_array.shape, dtype, buffer, offset, strides, order)
         obj[:] = datetime64_array
-
+        
         # Set the timezone and offset of the array
         obj.tz = tz_
         obj.tz_offset = tz_offset_ if tz_offset_ else datetime.timedelta(0)
@@ -151,8 +151,8 @@ class DatetimeLikeArray(np.ndarray):
         converted_arr = [dt.replace(tzinfo=self.tz) for dt in list_arr]
 
         return converted_arr
-
-    def to_file(self, fp: Union[IO, str, Path], tz: Union[datetime.tzinfo, None] = None):
+    
+    def to_file(self, fp: Union[IO, str, Path], tz: Optional[datetime.tzinfo] = None):
         """
         Save a DatetimeLikeArray instance to a text file.
 
@@ -184,11 +184,11 @@ class DatetimeLikeArray(np.ndarray):
     def from_array(
         cls,
         input_array: np.typing.NDArray[Union[np.number, np.datetime64]],
-        tz: Union[datetime.tzinfo, None] = None
+        tz: Optional[datetime.tzinfo] = None
     ):
         """
         Convert a numpy array to a DatetimeLikeArray instance.
-
+        
         Args:
             input_array (np.ndarray): NumPy array containing datetime values.
             tz (datetime.tzinfo, optional): Timezone of the input datetime values.
@@ -204,7 +204,7 @@ class DatetimeLikeArray(np.ndarray):
         return cls(input_array=array, dtype=input_array.dtype)
 
     @classmethod
-    def from_fp(cls, fp: Union[IO, str, Path], dtype: Type, tz: Union[datetime.tzinfo, None] = None):
+    def from_fp(cls, fp: Union[IO, str, Path], dtype: Type, tz: Optional[datetime.tzinfo] = None):
         """
         Load a text file and convert it to a DatetimeLikeArray instance.
 
@@ -212,7 +212,7 @@ class DatetimeLikeArray(np.ndarray):
             fp (Union[IO, str, Path]): File path or file-like object to read from.
             dtype (Type): Data type of the values in the file.
             tz (datetime.tzinfo, optional): Timezone to assign to the loaded data.
-
+        
         Returns:
             DatetimeLikeArray: A new instance with timezone awareness.
         """
@@ -223,3 +223,56 @@ class DatetimeLikeArray(np.ndarray):
         dtype_ = 'datetime64[s]' if not dtype else dtype
         data = np.loadtxt(fp, dtype=dtype_)
         return cls.from_array(input_array=data, tz=tz)
+
+    @classmethod 
+    def from_iter(cls, gen: Iterable[DatetimeLike], dtype: Type, tz: Optional[datetime.tzinfo] = None):
+        """
+        
+        Create a DatetimeLikeArray object from an Iterable with DatetimeLike yields
+
+        Args:
+            gen (Iterable[DatetimeLike]): An iterable that yields DatetimeLike values
+            dtype (Type): Data type of the values in the file.
+            tz (datetime.tzinfo, optional): Timezone to assign to the loaded data.
+        
+        Returns:
+            DatetimeLikeArray: A new instance with timezone awareness.
+        """
+
+        def wrapper_gen(gen: Iterable[DatetimeLike]) -> Iterable[DatetimeLike]: 
+
+            for value in gen(): 
+                
+                # If it is timezone-aware, remove the timezone
+                if isinstance(value, datetime.datetime): 
+                    a = value.replace(tzinfo=None)
+                    
+                    yield a
+                
+                else: 
+                    yield value
+        
+        naive_array = np.fromiter(wrapper_gen(gen), dtype=dtype)
+        
+        if tz:
+            tz_offset_ = datetime.datetime.now(tz).utcoffset()
+            seconds_offset = tz_offset_.total_seconds() if tz_offset_ else 0
+            np_offset = np.timedelta64(int(np.abs(seconds_offset)), 's')
+            
+            if seconds_offset < 0:
+                naive_array += np_offset
+            else:
+                naive_array -= np_offset
+            
+            # Initialize an NDArray and populate with the datetime values
+            obj = super().__new__(cls, naive_array.shape, dtype)
+            obj[:] = naive_array
+            
+            # Set the timezone and offset of the array
+            obj.tz = tz
+            obj.tz_offset = tz_offset_ if tz_offset_ else datetime.timedelta(0)
+            return obj
+        
+        obj = super().__new__(cls, naive_array.shape, dtype)
+        obj[:] = naive_array
+        return obj

--- a/aqua_blue/datetimelikearray.py
+++ b/aqua_blue/datetimelikearray.py
@@ -241,7 +241,7 @@ class DatetimeLikeArray(np.ndarray):
 
         def wrapper_gen(gen): 
             
-            for value in gen(): 
+            for value in gen: 
                 
                 # If it is timezone-aware, remove the timezone
                 if isinstance(value, datetime.datetime): 

--- a/aqua_blue/datetimelikearray.py
+++ b/aqua_blue/datetimelikearray.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import numpy as np
 
-from typing import List, IO, Union, TypeVar, Type, Sequence, Iterable, Optional
+from typing import List, IO, Union, TypeVar, Type, Sequence, Generator, Optional
 
 from zoneinfo import ZoneInfo
 import datetime
@@ -223,15 +223,15 @@ class DatetimeLikeArray(np.ndarray):
         dtype_ = 'datetime64[s]' if not dtype else dtype
         data = np.loadtxt(fp, dtype=dtype_)
         return cls.from_array(input_array=data, tz=tz)
-
+    
     @classmethod 
-    def from_iter(cls, gen: Iterable[DatetimeLike], dtype: Type, tz: Optional[datetime.tzinfo] = None):
+    def from_iter(cls, gen: Generator[DatetimeLike, None, None], dtype: Type, tz: Optional[datetime.tzinfo] = None):
         """
         
         Create a DatetimeLikeArray object from an Iterable with DatetimeLike yields
 
         Args:
-            gen (Iterable[DatetimeLike]): An iterable that yields DatetimeLike values
+            gen (Generator[DatetimeLike, None, None]): A generator that yields DatetimeLike values
             dtype (Type): Data type of the values in the file.
             tz (datetime.tzinfo, optional): Timezone to assign to the loaded data.
         
@@ -239,14 +239,13 @@ class DatetimeLikeArray(np.ndarray):
             DatetimeLikeArray: A new instance with timezone awareness.
         """
 
-        def wrapper_gen(gen: Iterable[DatetimeLike]) -> Iterable[DatetimeLike]: 
-
+        def wrapper_gen(gen): 
+            
             for value in gen(): 
                 
                 # If it is timezone-aware, remove the timezone
                 if isinstance(value, datetime.datetime): 
                     a = value.replace(tzinfo=None)
-                    
                     yield a
                 
                 else: 

--- a/aqua_blue/time_series.py
+++ b/aqua_blue/time_series.py
@@ -2,9 +2,10 @@
 Module defining the TimeSeries object
 """
 
-from typing import IO, Union, Generic, TypedDict, Sequence
+from typing import IO, Union, Generic, TypedDict, Sequence, List
 from pathlib import Path
 import warnings
+import io 
 
 from dataclasses import dataclass
 import numpy as np
@@ -120,21 +121,34 @@ class TimeSeries(Generic[TimeDeltaLike]):
         
         # Get the number of columns
         data = np.genfromtxt(fp, delimiter=",", dtype=None)
-        cols = data.dtype.names
         
-        # # Take out the times data from genfromtxt call 
-        times_ = data[:][cols[time_index]]
+        cols : List[Union[int, str]]
+
+        if isinstance(data[0], np.void) and data.dtype.names: 
+            cols = list(data.dtype.names) 
+            times_ = data[:][cols[time_index]]
+        else: 
+            cols = [i for i in range(data.shape[1])]
+            times_ = data[:, time_index]
+        
+        if isinstance(fp, io.IOBase):
+            fp.seek(0)
         
         # Get the dependent variables 
         var_indices = [i for i in range(0, len(cols)) if i != time_index] 
         dependent = np.loadtxt(fp, delimiter=',', usecols=var_indices)
         
         if isinstance(times_[0], str):
-            times_ = [parser.parse(i).replace(tzinfo=tz) for i in times_]
+            datetimes_ : List[datetime] = [parser.parse(i).replace(tzinfo=tz) for i in times_]
+        
+            return TimeSeries(
+                dependent_variable=dependent,
+                times=DatetimeLikeArray(datetimes_, dtype=times_dtype)
+            )
         
         return TimeSeries(
             dependent_variable=dependent,
-            times=DatetimeLikeArray(times_, dtype=times_dtype)
+            times=DatetimeLikeArray.from_array(times_)
         )
 
     def to_dict(self) -> TimeSeriesTypedDict:
@@ -161,7 +175,7 @@ class TimeSeries(Generic[TimeDeltaLike]):
     def __eq__(self, other) -> bool:
         """
         Checks equality between two TimeSeries instances.
-
+        
         Returns:
             bool: True if both instances have the same times and dependent variables.
         """
@@ -198,7 +212,7 @@ class TimeSeries(Generic[TimeDeltaLike]):
             dependent_variable=self.dependent_variable + other.dependent_variable,
             times=self.times
         )
-
+    
     def __sub__(self, other):
         """
         Subtracts two TimeSeries instances element-wise.

--- a/aqua_blue/time_series.py
+++ b/aqua_blue/time_series.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from zoneinfo import ZoneInfo
 from datetime import datetime
-from dateutil import parser # type: ignore
+from dateutil import parser
 
 from .datetimelikearray import DatetimeLikeArray, TimeDeltaLike
 
@@ -105,7 +105,6 @@ class TimeSeries(Generic[TimeDeltaLike]):
         return self.dependent_variable.shape[1]
 
     @classmethod
-    def from_csv(cls, fp: Union[IO, str, Path], times_dtype, tz: Union[ZoneInfo, None] = None, time_index: int = 0):
     def from_csv(cls, fp: Union[IO, str, Path], times_dtype, tz: Union[ZoneInfo, None] = None, time_index: int = 0):
         """
         Loads time series data from a CSV file.

--- a/aqua_blue/time_series.py
+++ b/aqua_blue/time_series.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from zoneinfo import ZoneInfo
 from datetime import datetime
-from dateutil import parser
+from dateutil import parser # type: ignore
 
 from .datetimelikearray import DatetimeLikeArray, TimeDeltaLike
 

--- a/aqua_blue/time_series.py
+++ b/aqua_blue/time_series.py
@@ -9,6 +9,7 @@ import warnings
 import io 
 import csv
 import os
+import codecs
 
 from dataclasses import dataclass
 import numpy as np
@@ -148,8 +149,9 @@ class TimeSeries(Generic[TimeDeltaLike]):
                     yield from csv.DictReader(file, delimiter=",")
         
             if isinstance(fp, io.BytesIO):
-                fp.seek(0)
-                yield from csv.DictReader(io.TextIOWrapper(fp, encoding='utf-8'), delimiter=",")
+                # Use codecs, because decoding directly is an eager operation
+                fp.seek(0) 
+                yield from csv.DictReader(codecs.getreader("utf-8")(fp))
             
             if isinstance(fp, io.StringIO):
                 fp.seek(0)
@@ -162,7 +164,7 @@ class TimeSeries(Generic[TimeDeltaLike]):
                 if max_rows and i >= max_rows:
                     break
                 for col in dependent_var_cols: 
-                     yield dep_var_conversion(row[col]) 
+                    yield dep_var_conversion(row[col]) 
         
         # Generator for lazy times processing
         def process_times(): 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dev = [
     "ruff~=0.9.4",
     "mypy~=1.13.0",
     "pdoc~=15.0.1",
-    "types-python-dateutil~=2.9.0.20241206"
+    "types-python-dateutil~=2.9.0.20241206",
+    "requests~=2.32.3"
 ]
 examples = [
     "scipy~=1.13.1", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ classifiers = [
 dependencies = [
     "numpy ~= 2.0.2",
     "tzdata~=2025.1",
-    "python-dateutil~=2.9.0.post0"
+    "python-dateutil~=2.9.0.post0",
+    "types-python-dateutil~=2.9.0.20241206"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "numpy ~= 2.0.2",
     "tzdata~=2025.1",
+    "python-dateutil~=2.9.0.post0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "numpy ~= 2.0.2",
     "tzdata~=2025.1",
     "python-dateutil~=2.9.0.post0",
-    "types-python-dateutil~=2.9.0.20241206"
 ]
 
 [project.urls]
@@ -43,6 +42,7 @@ dev = [
     "ruff~=0.9.4",
     "mypy~=1.13.0",
     "pdoc~=15.0.1",
+    "types-python-dateutil~=2.9.0.20241206"
 ]
 examples = [
     "scipy~=1.13.1", 

--- a/test_lib.py
+++ b/test_lib.py
@@ -54,7 +54,7 @@ def test_can_save_and_load_time_series():
     with BytesIO() as buffer:
         t_original.save(buffer)
         buffer.seek(0)
-        t_loaded = time_series.TimeSeries.from_csv(buffer)
+        t_loaded = time_series.TimeSeries.from_csv(buffer, times_dtype=float)
     
     assert t_original == t_loaded
 

--- a/test_lib.py
+++ b/test_lib.py
@@ -239,6 +239,53 @@ def datetime_series():
         times=times_
     )
 
+def from_iter_float():
+    def gen(): 
+        a = 0
+        while a < 10: 
+            yield a
+            a +=1
+    
+    ts = datetimelikearray.DatetimeLikeArray.from_iter(gen, float)
+    
+    assert(ts == np.arange(10))
+
+def from_iter_naive(): 
+    time_init = datetime(
+        year=2025,
+        month=3,
+        day=1,
+        hour=12,
+        tzinfo=ZoneInfo("UTC")
+    )
+    
+    def gen(): 
+        i = 0 
+        while i < 10: 
+            yield time_init + timedelta(seconds=3600*i)
+            i += 1
+    
+    ts = datetimelikearray.DatetimeLikeArray.from_iter(gen, 'datetime64[s]')
+    assert(ts == list(gen()))
+
+def from_iter_aware():
+    time_init = datetime(
+        year=2025,
+        month=3,
+        day=1,
+        hour=12,
+        tzinfo=ZoneInfo("America/Chicago")
+    )
+    
+    def gen(): 
+        i = 0 
+        while i < 10: 
+            yield time_init + timedelta(seconds=3600*i)
+            i += 1
+    
+    ts = datetimelikearray.DatetimeLikeArray.from_iter(gen, 'datetime64[s]', tz=ZoneInfo("America/Chicago"))
+    assert(ts.to_list() == list(gen()))
+
 def csv_from_string_io():
     # grab csv data from somewhere online
     req = requests.get("https://www.ncei.noaa.gov/data/global-summary-of-the-day/access/2024/01001099999.csv")

--- a/test_lib.py
+++ b/test_lib.py
@@ -1,4 +1,4 @@
-from io import BytesIO
+from io import BytesIO, StringIO
 from copy import deepcopy
 from datetime import datetime, timedelta
 
@@ -6,9 +6,12 @@ import pytest
 import numpy as np
 
 from zoneinfo import ZoneInfo
+import requests
 
 from aqua_blue import time_series, utilities, reservoirs, readouts, models, datetimelikearray
 
+
+# Fixtures
 
 @pytest.fixture
 def cosine_sine_series():
@@ -36,6 +39,7 @@ def datetime_arr():
 
     return times_ 
 
+# TimeSeries
 def test_non_uniform_timestep_error():
     
     with pytest.raises(ValueError):
@@ -52,9 +56,14 @@ def test_can_save_and_load_time_series():
     
     t_original = time_series.TimeSeries(dependent_variable=np.ones(shape=(10, 2)), times=np.arange(10))
     with BytesIO() as buffer:
-        t_original.save(buffer)
+        t_original.save(buffer, header="TIMES,COL1,COL2")
         buffer.seek(0)
-        t_loaded = time_series.TimeSeries.from_csv(buffer, times_dtype=float)
+        t_loaded = time_series.TimeSeries.from_csv(
+            fp=buffer,
+            times_dtype=float,
+            time_col="TIMES",
+            dependent_var_cols=["COL1", "COL2"]
+        )
     
     assert t_original == t_loaded
 
@@ -229,3 +238,53 @@ def datetime_series():
         dependent_variable=dependent_variables, 
         times=times_
     )
+
+def csv_from_string_io():
+    # grab csv data from somewhere online
+    req = requests.get("https://www.ncei.noaa.gov/data/global-summary-of-the-day/access/2024/01001099999.csv")
+    
+    # time col probably better referenced by name
+    # timesteps aren't uniform after row 87
+    time_col = "DATE"
+    dependent_var_cols = ["TEMP", "WDSP"]
+    max_rows = 87
+    
+    
+    # write txt response to StringIO object so we can use it like an fp
+    with StringIO() as file:
+        txt = req.text
+        file.write(txt)
+        file.seek(0)
+    
+        ts = time_series.TimeSeries.from_csv(
+            fp=file,
+            time_col=time_col,
+            dependent_var_cols=dependent_var_cols,
+            times_dtype='datetime64[s]',
+            max_rows=87,
+        )
+
+def csv_from_bytesio():
+    # grab csv data from somewhere online
+    req = requests.get("https://www.ncei.noaa.gov/data/global-summary-of-the-day/access/2024/01001099999.csv")
+    
+    # time col probably better referenced by name
+    # timesteps aren't uniform after row 87
+    time_col = "DATE"
+    dependent_var_cols = ["TEMP", "WDSP"]
+    max_rows = 87
+    
+    
+    # write txt response to StringIO object so we can use it like an fp
+    with BytesIO() as file:
+        txt = req.text
+        file.write(txt)
+        file.seek(0)
+    
+        ts = time_series.TimeSeries.from_csv(
+            fp=file,
+            time_col=time_col,
+            dependent_var_cols=dependent_var_cols,
+            times_dtype='datetime64[s]',
+            max_rows=87,
+        )


### PR DESCRIPTION
Closes #45 

@jwjeffr  This isn't ready yet (need to add way more test cases to make sure it's robust) but I wanted your feedback on the lazy evaluation. Currently, only the dependent variables can be lazily evaluated because of the way `DatetimeLikeArray` is set up, but I think we can figure out some way to implement lazy evaluation for `times`, do you think it's worth it?

Update: `from_iter` is implemented for `DatetimeLikeArray`, so `from_csv` can be completely lazy now.